### PR TITLE
Add flag to explicitly ignore files in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Flag to explicitly ignore a file
+*__gitignore__*
+


### PR DESCRIPTION
This way, if I put `__gitignore__` in a filename (e.g. scratch notebooks that I don't want to put in version control), the file won't show up as untracked when I do `git status`.